### PR TITLE
Renamed FT Politics, removed it from General Election

### DIFF
--- a/data.json
+++ b/data.json
@@ -445,7 +445,7 @@
 		"tags": [
 			[
 				"primarySection",
-				"FT UK General Election 2015 podcast",
+				"FT Politics",
 				"Y2MyOTBmOGQtYWQyMi00NjVhLTkxNmMtNTkwOGY1ZWQwM2Mw-QnJhbmRz"
 			],
 			[
@@ -457,11 +457,6 @@
 				"sections",
 				"UK Politics & Policy",
 				"OA==-U2VjdGlvbnM="
-			],
-			[
-				"topics",
-				"General Election",
-				"OTAzZjM5YTgtZGU1Ny00MjU5LTgxMmEtZGIzMGY4YTg5NDJi-VG9waWNz"
 			]
 		],
 		"links": [

--- a/data.json
+++ b/data.json
@@ -445,7 +445,7 @@
 		"tags": [
 			[
 				"primarySection",
-				"FT Politics",
+				"FT Politics podcast",
 				"Y2MyOTBmOGQtYWQyMi00NjVhLTkxNmMtNTkwOGY1ZWQwM2Mw-QnJhbmRz"
 			],
 			[


### PR DESCRIPTION
Renamed General Election podcast to FT Politics and removed it from the General Election topic as it was flooding it.

@i-like-robots will this do it?
