### PR TITLE
Change FT Arts podcast title

### DIFF
--- a/data.json
+++ b/data.json
@@ -29,7 +29,7 @@
 		"tags": [
 			[
 				"primarySection",
-				"FT Arts podcast",
+				"FT Life of a Song podcast",
 				"NzA0NWQ2OTUtNDdhZC00ZGMxLWI4MGEtODZkYTY5MjQ0ZTk1-QnJhbmRz"
 			],
 			[


### PR DESCRIPTION
The topic tag has been renamed by Editorial - updating mapping to reflect this.